### PR TITLE
🐛 fix: use default arg for highlights

### DIFF
--- a/lua/eyeliner/view.lua
+++ b/lua/eyeliner/view.lua
@@ -21,10 +21,10 @@ function M.set_hl_colors()
 
   local opts = config.opts
   vim.api.nvim_set_hl(0, 'EyelinerPrimary', {
-    fg = primary_color, bold = opts.bold, underline = opts.underline
+    fg = primary_color, bold = opts.bold, underline = opts.underline, default = true
   })
   vim.api.nvim_set_hl(0, 'EyelinerSecondary', {
-    fg = secondary_color, bold = opts.bold, underline = opts.underline
+    fg = secondary_color, bold = opts.bold, underline = opts.underline, default = true
   })
 end
 


### PR DESCRIPTION
The `default` argument in the `:hi` calls were removed in the recent refactor commit (not sure if that was intentional): https://github.com/jinh0/eyeliner.nvim/commit/d1adaaeb292644dfb7958d3dbc8cace8315ea3e5

Removing this prevented `EyelinerPrimary` and `EyelinerSecondary` highlight group overrides from working properly in cases where the plugin is loaded after the override. An example of this is if you lazy-load the plugin after your colorscheme has been set up.

This might also relate to the recent discussion in issue #2, since adding `default = true` means that the user-defined highlight group override (outside of plugin's `setup` call) would be the source of truth if it exists.