### PR TITLE
fix: remove `nvim_del_autocmd` call

### DIFF
--- a/lua/eyeliner/view.lua
+++ b/lua/eyeliner/view.lua
@@ -46,7 +46,6 @@ end
 function M.disable()
   if M.enabled then
     M.clear_highlight()
-    vim.api.nvim_del_autocmd('EyelinerToggle')
     vim.api.nvim_del_augroup_by_name('Eyeliner')
 
     M.enabled = false


### PR DESCRIPTION
`nvim_del_autocmd` deletes an autocommand by id, not name, so that line throws an error on each `:EyelinerDisable/Toggle`. (It refers to a non-existing autocommand anyway.)