### PR TITLE
fix: use `i` flag in feedkeys (fixes vim macros) 

### DIFF
--- a/lua/eyeliner/view.lua
+++ b/lua/eyeliner/view.lua
@@ -69,7 +69,7 @@ function M.enable()
 
           -- Default behavior
           vim.api.nvim_feedkeys(key .. char, 'in', true)
-       end)
+        end)
 
         return require('eyeliner.view').clear_cursor_highlight()
       end)

--- a/lua/eyeliner/view.lua
+++ b/lua/eyeliner/view.lua
@@ -68,11 +68,8 @@ function M.enable()
           local char = vim.fn.getcharstr()
 
           -- Default behavior
-
-
-          vim.api.nvim_feedkeys(key, 'n', true)
-          vim.api.nvim_feedkeys(char, 'n', true)
-        end)
+          vim.api.nvim_feedkeys(key .. char, 'in', true)
+       end)
 
         return require('eyeliner.view').clear_cursor_highlight()
       end)


### PR DESCRIPTION
use `i` flag to fix #17 (f was executed at the end of a macro)

snippet from `:help feedkeys()`:
```
By default the string is added to the end of the typeahead
buffer, thus if a mapping is still being executed the
characters come after them.  Use the 'i' flag to insert before
other characters, they will be executed next, before any
characters from a mapping.
```