### PR TITLE
fix: handle plugin/ being loaded before setup() is called

### DIFF
--- a/lua/eyeliner/config.lua
+++ b/lua/eyeliner/config.lua
@@ -9,11 +9,20 @@ local defaults = {
 M.opts = defaults
 
 M.setup = function(opt)
+  local eyeliner = require('eyeliner')
+  local enabled = require('eyeliner.view').enabled
+
+  if enabled then
+    eyeliner.disable()
+  end
+
   M.opts = vim.tbl_deep_extend('force', {}, defaults, opt or {})
 
   if M.opts.debug then
-    vim.notify("DEBUG: " .. vim.inspect(M.opts))
+    vim.notify('DEBUG: ' .. vim.inspect(M.opts))
   end
+
+  eyeliner.enable()
 end
 
 return M

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -3,5 +3,4 @@ local eyeliner = require('eyeliner')
 vim.api.nvim_create_user_command('EyelinerEnable', eyeliner.enable, {})
 vim.api.nvim_create_user_command('EyelinerDisable', eyeliner.disable, {})
 vim.api.nvim_create_user_command('EyelinerToggle', eyeliner.toggle, {})
-
-eyeliner.enable()
+eyeliner.setup()


### PR DESCRIPTION
For plugin managers like Lazy.nvim, `init.lua` and `plugin/` will be loaded first, and then setup() will be called. This causes problems currently since enable is already called without the user's configuration.

Will fix https://github.com/jinh0/eyeliner.nvim/issues/15 with cases using above behavior. See https://github.com/folke/lazy.nvim/issues/123#issuecomment-1367773015 for details on the loading order.

This was the simplest change I could think of to handle repeated calls to enable(). If you feel there is a better refactor to be made, feel free to do so.