### PR TITLE
fix: don't clear other autocmds when changing colorscheme

### DIFF
--- a/fnl/eyeliner/shared.fnl
+++ b/fnl/eyeliner/shared.fnl
@@ -9,15 +9,16 @@
 
 ;; Enable Eyeliner's syntax highlighting, and setup ColorScheme autocmd
 (fn enable-highlights []
-  (let [primary (utils.get-hl "Constant")
-        secondary (utils.get-hl "Define")
-        dimmed (utils.get-hl "Comment")]
-    (utils.set-hl "EyelinerPrimary" primary.foreground)
-    (utils.set-hl "EyelinerSecondary" secondary.foreground)
-    (utils.set-hl "EyelinerDimmed" dimmed.foreground)
-    (utils.create-augroup "Eyeliner" {:clear true})
+  (let [callback (fn []
+    (let [primary (utils.get-hl "Constant")
+          secondary (utils.get-hl "Define")
+          dimmed (utils.get-hl "Comment")]
+      (utils.set-hl "EyelinerPrimary" primary.foreground)
+      (utils.set-hl "EyelinerSecondary" secondary.foreground)
+      (utils.set-hl "EyelinerDimmed" dimmed.foreground)))]
+    (callback)
     (utils.set-autocmd "ColorScheme"
-                       {:callback enable-highlights :group "Eyeliner"})))
+                        {:callback callback :group "Eyeliner"})))
 
 ;; Apply eyeliner (add highlight) for a given y and token
 (fn apply-eyeliner [y tokens]

--- a/lua/eyeliner/shared.lua
+++ b/lua/eyeliner/shared.lua
@@ -1,20 +1,24 @@
 local utils = require("eyeliner.utils")
 local ns_id = vim.api.nvim_create_namespace("eyeliner")
 local function enable_highlights()
-  local primary = utils["get-hl"]("Constant")
-  local secondary = utils["get-hl"]("Define")
-  local dimmed = utils["get-hl"]("Comment")
-  utils["set-hl"]("EyelinerPrimary", primary.foreground)
-  utils["set-hl"]("EyelinerSecondary", secondary.foreground)
-  utils["set-hl"]("EyelinerDimmed", dimmed.foreground)
-  utils["create-augroup"]("Eyeliner", {clear = true})
-  return utils["set-autocmd"]("ColorScheme", {callback = enable_highlights, group = "Eyeliner"})
+  local callback
+  local function _1_()
+    local primary = utils["get-hl"]("Constant")
+    local secondary = utils["get-hl"]("Define")
+    local dimmed = utils["get-hl"]("Comment")
+    utils["set-hl"]("EyelinerPrimary", primary.foreground)
+    utils["set-hl"]("EyelinerSecondary", secondary.foreground)
+    return utils["set-hl"]("EyelinerDimmed", dimmed.foreground)
+  end
+  callback = _1_
+  callback()
+  return utils["set-autocmd"]("ColorScheme", {callback = callback, group = "Eyeliner"})
 end
 local function apply_eyeliner(y, tokens)
   local function apply(token)
-    local _let_1_ = token
-    local x = _let_1_["x"]
-    local freq = _let_1_["freq"]
+    local _let_2_ = token
+    local x = _let_2_["x"]
+    local freq = _let_2_["freq"]
     local hl_group
     if (freq == 1) then
       hl_group = "EyelinerPrimary"


### PR DESCRIPTION
Currently, when changing colorscheme, all autocmds are cleared, so no new indicators appear when the cursor is moved.

The augroup is already created with `{:clear true}` before calling `enable-highlights`: https://github.com/jinh0/eyeliner.nvim/blob/c540d58bf52aa979d4cca639c60387ae0c0ccf88/fnl/eyeliner/main.fnl#L17, so there doesn't seem to be a need to clear again and then recreate the `ColorScheme` autocmd every time the colorscheme is changed.