### PR TITLE
docs(readme): fix incorrect config option names

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ Default values (in lazy.nvim):
 
       -- filetypes for which eyeliner should be disabled;
       -- e.g., to disable on help files:
-      -- disable_filetypes = {"help"}
-      disable_filetypes = {},
+      -- disabled_filetypes = {"help"}
+      disabled_filetypes = {},
 
       -- buftypes for which eyeliner should be disabled
-      -- e.g., disable_buftypes = {"nofile"}
-      disable_buftypes = {},
+      -- e.g., disabled_buftypes = {"nofile"}
+      disabled_buftypes = {},
 
       -- add eyeliner to f/F/t/T keymaps;
       -- see section on advanced configuration for more information


### PR DESCRIPTION
Use the correct [config option names](https://github.com/jinh0/eyeliner.nvim/blob/299e0cd45fe453b9f37b61c5efbd86e2c3180cfa/fnl/eyeliner/config.fnl#L9-L10) for disabling eyeliner by filetype and buftype.